### PR TITLE
feat: accept option format for "html" and generate HTML report [GIT-9]

### DIFF
--- a/src/__tests__/html.test.ts
+++ b/src/__tests__/html.test.ts
@@ -1,7 +1,7 @@
-import { generateSummaries } from '../formatters/summary-builder';
+import { generateHTML } from '../formatters/html';
 import { ParsedCommitType } from '../types';
 
-describe('formatters/summary-builder', () => {
+describe('formatters/html', () => {
   const commits: ParsedCommitType[] = [
     {
       type: 'chore',
@@ -45,38 +45,8 @@ describe('formatters/summary-builder', () => {
     jest.clearAllMocks();
   });
 
-  it('should return formatted Markdown and JSON output', () => {
-    const result = generateSummaries(commits);
-
-    expect(result).toBeDefined();
-  });
-
-  it("should generate Markdown summary when format is 'markdown'", () => {
-    const result = generateSummaries(commits, 'markdown');
-
-    expect(result).toEqual(
-      '## Bug\n' +
-        '- bug: resolve issue with CLI argument parsing (`a1b2c3d`)' +
-        '\n\n' +
-        '## Chore\n' +
-        '- initial scaffold for gitscope CLI with core folder structure, config, and base logic (`9912226`)' +
-        '\n\n' +
-        '## Other\n' +
-        '- miscellaneous changes 1 (`e4f5g6h`)' +
-        '\n' +
-        '- miscellaneous changes 2 (`f7g8h9i`)'
-    );
-  });
-
-  it("should generate JSON summary when format is 'json'", () => {
-    const result = generateSummaries(commits, 'json');
-
-    expect(result).toEqual(JSON.stringify(commits, null, 2));
-  });
-
-  it("should generate HTML summary when format is 'html'", () => {
-    const result = generateSummaries(commits, 'html');
-
+  it('should return formatted HTML document', () => {
+    const result = generateHTML(commits);
     expect(result).toContain('<!DOCTYPE html>');
     expect(result).toContain('<title>gitscope | HTML Report</title>');
     expect(result).toContain('<table>');

--- a/src/formatters/html.ts
+++ b/src/formatters/html.ts
@@ -1,0 +1,49 @@
+import { ParsedCommitType } from '../types';
+
+export function generateHTML(commits: ParsedCommitType[]): string {
+  const rows = commits
+    .map((commit) => {
+      return `
+      <tr>
+        <td><code>${commit.hash.slice(0, 7)}</code></td>
+        <td>${commit.author}</td>
+        <td>${commit.date}</td>
+        <td>${commit.type}</td>
+        <td>${commit.description}</td>
+      </tr>
+    `;
+    })
+    .join('');
+
+  return `
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+      <meta charset="UTF-8" />
+      <title>gitscope | HTML Report</title>
+      <style>
+        body { font-family: sans-serif; padding: 2rem; }
+        table { border-collapse: collapse; width: 100%; }
+        th, td { padding: 0.5rem; border: 1px solid #ccc; text-align: left; vertical-align: top; }
+        th { background: #f0f0f0; }
+        code { background: #eee; padding: 0.2rem 0.4rem; border-radius: 4px; }
+      </style>
+    </head>
+    <body>
+      <h1>gitscope | HTML Report</h1>
+      <table>
+        <thead>
+          <tr>
+            <th>Hash</th>
+            <th>Author</th>
+            <th>Date</th>
+            <th>Type</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>${rows}</tbody>
+      </table>
+    </body>
+    </html>
+  `;
+}

--- a/src/formatters/summary-builder.ts
+++ b/src/formatters/summary-builder.ts
@@ -1,4 +1,5 @@
 import { OutputFormatType, ParsedCommitType } from '../types';
+import { generateHTML } from './html';
 import { generateGroupedMarkdown } from './markdown';
 
 /**
@@ -18,6 +19,8 @@ export function generateSummaries(
       return generateGroupedMarkdown(commits);
     case 'json':
       return JSON.stringify(commits, null, 2);
+    case 'html':
+      return generateHTML(commits);
     default:
       return JSON.stringify(commits, null, 2);
   }


### PR DESCRIPTION
View [Linear issue](https://linear.app/gitscope/issue/GIT-9/feat-accept-option-format-for-html-and-generate-html-report) for more details