### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/create-pull-request.yml
+++ b/.github/workflows/create-pull-request.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - 'ENGG-*'
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   create-auto-pr:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/NitinNair89/gitscope-cli/security/code-scanning/1](https://github.com/NitinNair89/gitscope-cli/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. In this case:
- `contents: read` is needed to fetch branches and repository data.
- `pull-requests: write` is required to create pull requests.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`create-auto-pr`) to limit permissions to that job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
